### PR TITLE
LPK-4087 Adds invoice row comment to the common translations

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lupapiste/commons "0.9.50"
+(defproject lupapiste/commons "0.9.51"
   :description "Common domain code and resources for lupapiste applications"
   :url "https://www.evolta.fi"
   :license {:name "Eclipse Public License"

--- a/resources/shared_translations.txt
+++ b/resources/shared_translations.txt
@@ -1572,6 +1572,7 @@
 "invoices.operations.add-operation" "fi" "Lisää toimenpide"
 "invoices.rows.VAT" "fi" "ALV (€)"
 "invoices.rows.amount" "fi" "Määrä"
+"invoices.rows.comment" "fi" "Alennuksen perustelu"
 "invoices.rows.customrow" "fi" "Vapaarivi"
 "invoices.rows.discount-percent" "fi" "Ale (%)"
 "invoices.rows.total" "fi" "Yhteensä (€)"


### PR DESCRIPTION
https://evolta-cloud.atlassian.net/browse/LPK-4087

Invoice row comment is used for declaring the reason for a discount

Varsinainen käyttö täällä:
https://github.com/lupapiste/lupapiste-internal/pull/466