### PR TITLE
LPK-5816 Update ymparistoluvan-selventaminen state machine

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lupapiste/commons "0.12.9"
+(defproject lupapiste/commons "0.12.10"
   :description "Common domain code and resources for lupapiste applications"
   :url "https://www.lupapiste.fi"
   :license {:name "Eclipse Public License"

--- a/src/lupapiste_commons/states.cljc
+++ b/src/lupapiste_commons/states.cljc
@@ -61,11 +61,11 @@
 (def
   ^{:doc "See default-application-state-graph"}
   selventaminen-application-state-graph
-  (-> default-application-state-graph
-      (dissoc :verdictGiven :constructionStarted :extinct :appealed)
-      (merge {:submitted        [:sent :draft :canceled]
-              :sent             [:complementNeeded :closed :canceled]
-              :complementNeeded [:sent :canceled]})))
+  (merge
+    (select-keys default-application-state-graph [:draft :open :canceled])
+    {:submitted        [:acknowledged :draft :canceled]
+     :complementNeeded [:acknowledged :canceled]
+     :acknowledged     [:complementNeeded]}))
 
 (def
   ^{:doc "See default-application-state-graph"}


### PR DESCRIPTION
Tilakoneeseen korjattu niin, että käsittelyyn siirtäminen vie `ymparistoluvan-selventaminen` hakemuksen terminaalitilaan samalla tavalla kuin työnjohtajan ilmoituksellakin. Aiemmin terminaalitilaan ei päässyt käliltä.

Terminaalitilaksi myös vaihdettu "Ilmoitus hyväksytty" (eli `acknowledged`) aiemman "Valmistunut" (`closed`) sijaan.
Koska tämä on kertaluontoinen huomautus eikä valmistuva projekti.
Periaatteessa `final` eli "Lainvoimainen" tai `finished` ("Asia valmis") olisivat myös vaihtoehtoja.
Tietysti yksi vaihtoehto olisi luoda jokin täysin uusi tila.
