### PR TITLE
Bugi korjaus: Tyhjiä käännös arvoja ei enää korvata oletus kielen käännöksellä

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lupapiste/commons "1.0.18"
+(defproject lupapiste/commons "2.0.0"
   :description "Common domain code and resources for lupapiste applications"
   :url "https://www.lupapiste.fi"
   :license {:name "Eclipse Public License"

--- a/src/lupapiste_commons/i18n/core.clj
+++ b/src/lupapiste_commons/i18n/core.clj
@@ -16,16 +16,16 @@
 
 (defn replace-missing-texts [translations default-lang]
   (reduce (fn [acc [key strings]]
-            (assoc acc key (if (missing-translations? strings default-lang)
-                             (replace-missing strings default-lang)
-                             strings)))
+            (assoc acc key (replace-missing strings default-lang)))
           (ordered-map)
           translations))
 
 (defn read-translations
   ([] (read-translations (io/resource "translations.txt")))
-  ([input]
-   (update-in (resources/txt->map input) [:translations] replace-missing-texts default-lang)))
+  ([input & {:keys [fallback-to-default-lang]}]
+   (if fallback-to-default-lang
+     (update-in (resources/txt->map input) [:translations] replace-missing-texts default-lang)
+     (resources/txt->map input))))
 
 (defn combine-vec-or-map [left right]
   (if (every? vector? [left right])

--- a/test/lupapiste_commons/i18n/core_test.clj
+++ b/test/lupapiste_commons/i18n/core_test.clj
@@ -4,11 +4,20 @@
             [clojure.test :refer :all]
             [lupapiste-commons.i18n.core :refer :all]))
 
-(deftest use-default-lang
-  (testing "String from default language used if no translation present"
+(deftest read-translations
+  (testing ":fallback-to-default-lang flag treats empty strings as missing value
+            and replaces them with default language resouces value"
     (let [input [["label" "fi" "moi"]
                  ["label" "sv" ""]]
           string (s/join "\n" (map #(s/join " " (mapv pr-str %)) input))]
       (is (= {:languages [:fi :sv]
               :translations {'label {:fi "moi" :sv "moi"}}}
+             (read-translations (.getBytes string) :fallback-to-default-lang true)))))
+
+  (testing "By default empty string are not considered as missing translations"
+    (let [input [["label" "fi" "moi"]
+                 ["label" "sv" ""]]
+          string (s/join "\n" (map #(s/join " " (mapv pr-str %)) input))]
+      (is (= {:languages [:fi :sv]
+              :translations {'label {:fi "moi" :sv ""}}}
              (read-translations (.getBytes string)))))))


### PR DESCRIPTION
Aiemmin lupapisteessä käännökset toimivat seuraavasti

Lokalisointi avaimet on konfittu seuraavasti:

```
"state.open.clarification" "en" "(not submitted)"
"state.open.clarification" "fi" "(ei jätetty)"
"state.open.clarification" "sv" ""
```

Ja replissä
```
(require '[lupapalvelu.i18n :as l])
=> nil
(get
  (:sv l/localizations) "state.open.clarification")
=> "(ei jätetty)"
```

Tämä PR korjaa toiminnallisuuden niin, että jatkossa "" pystyy tyhjänä stringinä.