### PR TITLE
LPK-6274 Onkalon tuki YMP-luville ja -liitetyypeille

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lupapiste/commons "3.0.0"
+(defproject lupapiste/commons "3.1.0"
   :description "Common domain code and resources for lupapiste applications"
   :url "https://www.lupapiste.fi"
   :license {:name "Eclipse Public License"

--- a/src/lupapiste_commons/archive_metadata_schema.clj
+++ b/src/lupapiste_commons/archive_metadata_schema.clj
@@ -23,15 +23,19 @@
     []
     (partition 2 groups)))
 
-(def document-and-attachment-types (-> document-types
-                                       (concat (groups->dotted-keywords attachment-types/Rakennusluvat-v2))
-                                       (concat (groups->dotted-keywords attachment-types/YleistenAlueidenLuvat-v2))))
+(def document-and-attachment-types (->> [attachment-types/Rakennusluvat-v2
+                                         attachment-types/YleistenAlueidenLuvat-v2
+                                         attachment-types/Ymparisto-types]
+                                        (mapcat groups->dotted-keywords)
+                                        (distinct)
+                                        (concat document-types)))
 
 (def valid-operations (concat operations/r-operations
                               operations/ya-operations
                               operations/deprecated-ya-operations
                               operations/p-operations
-                              operations/archiving-project-operations))
+                              operations/archiving-project-operations
+                              operations/ymp-operations))
 
 (def valid-usage-types (map :name usages/rakennuksen-kayttotarkoitus))
 

--- a/src/lupapiste_commons/operations.cljc
+++ b/src/lupapiste_commons/operations.cljc
@@ -90,6 +90,40 @@
    :ya-sijoituslupa-sahko-data-ja-muiden-kaapelien-sijoittaminen
    :ya-sijoituslupa-vesi-ja-viemarijohtojen-sijoittaminen])
 
+(def ymp-operations
+  "YI, YM, YL, MAL and VVVL operations allowed in archiving"
+  [:meluilmoitus
+   :yleinen-ilmoitus
+   :koeluontoinen-toiminta
+   :ilmoitus-poikkeuksellisesta-tilanteesta
+   :ylijaamamaiden-hyodyntaminen
+   :jatteiden-hyodyntaminen-maarakentamisessa
+   :rekisterointi-ilmoitus
+   :lannan-varastointi
+   :lannan-levittamisesta-poikkeustilanteessa
+   :pima
+   :kaytostapoistetun-oljy-tai-kemikaalisailion-jattaminen-maaperaan
+   :talousjatevesien-kasittelysta-poikkeaminen
+   :maa-aineslupa
+   :maa-aineslupa-jatkoaika
+   :maa-ainesten-kotitarveotto
+   :yhteiskasittely-maa-aines-ja-ymparistoluvalle
+   :yl-uusi-toiminta
+   :yl-olemassa-oleva-toiminta
+   :yl-toiminnan-muutos
+   :vvvl-vesijohdosta
+   :vvvl-viemarista
+   :vvvl-vesijohdosta-ja-viemarista
+   :vvvl-hulevesiviemarista
+   :jatteen-keraystoiminta
+   :muistomerkin-rauhoittaminen
+   :maastoliikennelaki-kilpailut-ja-harjoitukset
+   :vesiliikennelaki-kilpailut-ja-harjoitukset
+   :yl-puiden-kaataminen
+   :ymparistoluvan-selventaminen
+   :leirintaalueilmoitus
+   :kirjallinen-vireillepano])
+
 (def deprecated-ya-operations
   "Add retired YA operations here to keep them valid in archiving. Leave translations available."
   [:ya-kayttolupa-muu-liikennealuetyo])


### PR DESCRIPTION
[LPK-6274](https://cloudpermit.atlassian.net/browse/LPK-6274)

Tiketiltä: "Onkaloon arkistoinnissa sallitut arvot validoidaan lupapiste-commons.archive-metadata-schema -nimiavaruuden avulla. YMP-liitetyyppien lisääminen tuettujen joukkoon riittänee mahdollistamaan arkistoinnin."