### PR TITLE
LPK-6417 Include v1 environmental attachment types in the list of all types

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lupapiste/commons "4.1.0"
+(defproject lupapiste/commons "4.1.1"
   :description "Common domain code and resources for lupapiste applications"
   :url "https://www.lupapiste.fi"
   :license {:name "Eclipse Public License"

--- a/src/lupapiste_commons/attachment_types.cljc
+++ b/src/lupapiste_commons/attachment_types.cljc
@@ -603,4 +603,5 @@
     Kiinteistotoimitus
     Rakennusluvat-v2
     YleistenAlueidenLuvat-v2
+    Ymparisto-types ; For backward compatibility
     Ymparisto-types-v2))


### PR DESCRIPTION
For backward compatibility, include the first version of environmental attachment types in the list of all attachment types

https://cloudpermit.atlassian.net/browse/LPK-6417