### PR TITLE
LPK-6754: Fix stale translation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lupapiste/commons "5.2.6"
+(defproject lupapiste/commons "5.2.7"
   :description "Common domain code and resources for lupapiste applications"
   :url "https://www.lupapiste.fi"
   :license {:name         "Eclipse Public License"

--- a/resources/shared_translations.txt
+++ b/resources/shared_translations.txt
@@ -4943,7 +4943,7 @@
 "operations.tree.lannan-varastointi" "fi" "Ilmoitus lannan varastointitilavuudesta poikkeamisesta (aumausilmoitus)"
 "operations.tree.lannan-varastointi" "sv" "Anmälan om undantag från gödslets lagringsvolym (lagring av gödsel i stackar)"
 "operations.tree.lannan-varastointi-v2" "en" "Notice of a deviation to manure storage volume (9 §)"
-"operations.tree.lannan-varastointi-v2" "fi" "Ilmoitus lannan varastointitilavuudesta poikkeamisesta (aumausilmoitus) (9 §)"
+"operations.tree.lannan-varastointi-v2" "fi" "Ilmoitus lannan tai lannoitevalmisteen poikkeuksellisesta varastoinnista (aumausilmoitus) (9 §)"
 "operations.tree.lannan-varastointi-v2" "sv" "Anmälan om undantag från gödsellagringsvolym (anmälan av lagring i stack) (9 §)"
 "operations.tree.leikkipaikan-tai-koiratarhan-sijoittaminen" "en" "Placement of a playground or dog park"
 "operations.tree.leikkipaikan-tai-koiratarhan-sijoittaminen" "fi" "Leikkipaikan tai koiratarhan sijoittaminen"


### PR DESCRIPTION
The `operations.tree.lannan-varastointi-v2` did not match the `operations.lannan-varastointi-v2` translation.

--

Korjaa alunperin [TT-22643](https://cloudpermit.atlassian.net/browse/TT-22643):lla huomatun termien epäselvyyden.

[TT-22643]: https://cloudpermit.atlassian.net/browse/TT-22643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ