### PR TITLE
TT-23040 Lisätään loppukatselmuksen pöytäkirja YA/A-liitetyyppeihin 🌭 🔥 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lupapiste/commons "5.2.10"
+(defproject lupapiste/commons "5.2.11"
   :description "Common domain code and resources for lupapiste applications"
   :url "https://www.lupapiste.fi"
   :license {:name         "Eclipse Public License"

--- a/src/lupapiste_commons/attachment_types.cljc
+++ b/src/lupapiste_commons/attachment_types.cljc
@@ -300,8 +300,8 @@
                     :valokuva
                     :valtakirja]
    :osapuolet [:patevyystodistus]
-   ;; This is needed for statement attachments to work.
-   :katselmukset_ja_tarkastukset [:katselmuksen_tai_tarkastuksen_poytakirja]
+   :katselmukset_ja_tarkastukset [:katselmuksen_tai_tarkastuksen_poytakirja
+                                  :loppukatselmuksen_poytakirja]
    :ennakkoluvat_ja_lausunnot [:lausunto]
    :muut [:muu
           :paatos
@@ -316,8 +316,8 @@
                     :valokuva
                     :valtakirja]
    :osapuolet [:patevyystodistus]
-   ;; This is needed for statement attachments to work.
-   :katselmukset_ja_tarkastukset [:katselmuksen_tai_tarkastuksen_poytakirja]
+   :katselmukset_ja_tarkastukset [:katselmuksen_tai_tarkastuksen_poytakirja
+                                  :loppukatselmuksen_poytakirja]
    :ennakkoluvat_ja_lausunnot [:lausunto]
    :muut [:muu
           :paatos


### PR DESCRIPTION
Muutoksena sinällään selkee, mutta tehdään PR kirjanpidon vuoksi. Perusteellisempi keskustelu Lupapisteen vastaavassa PR:ssä.