### PR TITLE
LPK-7072 GCP-tuki commonsin autologinille  🆔 🌭 🔥  

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lupapiste/commons "5.2.12"
+(defproject lupapiste/commons "5.2.13"
   :description "Common domain code and resources for lupapiste applications"
   :url "https://www.lupapiste.fi"
   :license {:name         "Eclipse Public License"

--- a/src/lupapiste_commons/ring/autologin.clj
+++ b/src/lupapiste_commons/ring/autologin.clj
@@ -1,6 +1,7 @@
 (ns lupapiste-commons.ring.autologin
-  (:require [clojure.core.memoize :as memo]
-            [clj-http.client :as http]
+  (:require [clj-http.client :as http]
+            [clojure.core.memoize :as memo]
+            [clojure.string :as s]
             [taoensso.timbre :as timbre]))
 
 (defn- keyword-authz [org-authz]
@@ -20,11 +21,49 @@
 (def ^{:arglists '([url basic-auth request-ip])} fetch-login-user
   (memo/ttl do-fetch-login-user :ttl/threshold 5000))
 
+(defn- blank-as-nil [s]
+  (when-not (some-> s s/blank?)
+    s))
+
+(defn client-ip-map
+  "Resolves remote client ip header values."
+  [{:keys                     [remote-addr]
+    {:strs [x-real-ip
+            x-forwarded-for]} :headers}]
+  (->> {:remote-addr     remote-addr
+        :x-real-ip       x-real-ip
+        :x-forwarded-for x-forwarded-for}
+       (filter (comp blank-as-nil second))
+       (into {})))
+
+(defn client-ip
+  "Parses HTTP `request` and returns the originating ip address for the remote client. The
+  address is then later resolved against the organization autologin configuration. If
+  `gcp?` is true (default) the `x-forwarded-for` is taken into account and prioritized,
+  since it is used by GCP."
+  ([request gcp?]
+   (let [{:keys [remote-addr x-forwarded-for
+                 x-real-ip]} (client-ip-map request)]
+     (or
+       (when gcp?
+         ;; Note: this x-forwarded-for parsing is GCP specific!
+         ;; GCP appends client IP + load balancer IP after whatever existing contents
+         ;; the header might already have
+         (when-let [[_lb-ip ip & _] (some-> x-forwarded-for
+                                            ;; Should contain at least two addresses
+                                            (s/split #",")
+                                            reverse)]
+           (some-> ip s/trim blank-as-nil)))
+       x-real-ip
+       remote-addr)))
+  ([request] (client-ip request true)))
+
 (defn wrap-sso-autologin [handler autologin-check-url]
-  (fn [{:keys [headers remote-addr] :as request}]
-    (let [{:strs [authorization x-real-ip]} headers]
+  (fn [{:keys [headers] :as request}]
+    (let [{:strs [authorization]} headers
+          ip                      (client-ip request)]
       (try
-        (if-let [user (fetch-login-user autologin-check-url authorization (or x-real-ip remote-addr))]
+        (if-let [user (fetch-login-user autologin-check-url authorization ip)]
           (-> (assoc request :autologin-user user)
               (handler))
           (handler request))


### PR DESCRIPTION
## [LPK-7072](https://cloudpermit.atlassian.net/browse/LPK-7072)
Kun aiemmin korjattiin Lupapisteen autologinin ip-kaivuu, niin ei hoksattu, että Lupadoku ja TOJ käyttävät commonsin rinnakkaista mekanismia. Vastaavan tilanteen välttämiseksi tässä PR:ssä on nyt kopsittu Lupapisteen toteutus commonsiin.

Päivitän Lupadokun ja TOJin sitten kun tämä ja vastaava Lupapisteen PR cloudpermit/lupapiste#2028 on mergetty ja itestit menneet läpi.

[LPK-7072]: https://cloudpermit.atlassian.net/browse/LPK-7072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ