### PR TITLE
LPK-7108 Add parent document ID to archiving metadata

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lupapiste/commons "5.3.19"
+(defproject lupapiste/commons "5.3.20"
   :description "Common domain code and resources for lupapiste applications"
   :url "https://www.lupapiste.fi"
   :license {:name         "Eclipse Public License"

--- a/src/lupapiste_commons/archive_metadata_schema.clj
+++ b/src/lupapiste_commons/archive_metadata_schema.clj
@@ -115,7 +115,9 @@
      (s/optional-key :permit-expired)               s/Bool
      (s/optional-key :permit-expired-date)          s/Inst
      (s/optional-key :demolished)                   s/Bool
-     (s/optional-key :demolished-date)              s/Inst}
+     (s/optional-key :demolished-date)              s/Inst
+
+     (s/optional-key :parent-id)                    tms/NonEmptyStr}
     tms/AsiakirjaMetaDataMap))
 
 (def validation-schema-for-onkalo-update-metadata


### PR DESCRIPTION
The updated library contains new parent file ID optional field. This can be used for expressing parent-child relationships between files that have been archived. This allows us to connect the BIM attachments to the corresponding main BIM IFC files.