### PR TITLE
LPK-8250: MongoDB Ring SessionStore

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,7 @@
                  [dk.ative/docjure "1.18.0"]
                  [org.flatland/ordered "1.15.12"]
                  [prismatic/schema "1.4.1"]
+                 [metosin/schema-tools "0.13.1"]
                  [clj-http "3.12.3"]]
   :plugins [[com.jakemccrary/lein-test-refresh "0.26.0"]]
   :profiles {:dev      {:dependencies [[flare "0.2.9"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lupapiste/commons "5.3.30"
+(defproject lupapiste/commons "5.3.31"
   :description "Common domain code and resources for lupapiste applications"
   :url "https://www.lupapiste.fi"
   :license {:name         "Eclipse Public License"

--- a/src/lupapiste_commons/ring/mongo_session.clj
+++ b/src/lupapiste_commons/ring/mongo_session.clj
@@ -1,0 +1,128 @@
+(ns lupapiste-commons.ring.mongo-session
+  "MongoDB-backed Ring SessionStore
+  - Session keys are generated with 256-bit CSPRNG randomness (java.security.SecureRandom)
+    and encoded as URL-safe Base64 (43 characters, no padding).
+  - The database stores a SHA-256 hash of the session key as the document `_id`"
+  (:require [ring.middleware.session.store :as store]
+            [schema.core :as sc]
+            [schema-tools.core :as st])
+  (:import [java.security MessageDigest SecureRandom]
+           [java.util Base64 Date HexFormat]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private ^SecureRandom csprng (SecureRandom.))
+
+(defn- new-session-key
+  "Generates a 256-bit cryptographically random session key, returned as URL-safe Base64 (no padding)."
+  ^String []
+  (let [buf (byte-array 32)]
+    (.nextBytes csprng buf)
+    (.encodeToString (.withoutPadding (Base64/getUrlEncoder)) buf)))
+
+(def ^:private ^HexFormat hex-format (HexFormat/of))
+
+(defn session-id->db-id
+  "Derives the database document `_id` from the session key by computing its SHA-256 hash"
+  ^String [^String session-key]
+  (let [digest     (MessageDigest/getInstance "SHA-256")
+        hash-bytes (.digest digest (.getBytes session-key "UTF-8"))]
+    (.formatHex hex-format hash-bytes)))
+
+(defn- now-date ^Date [] (Date.))
+
+(defn coerce-org-authz
+  [org-authz]
+  (update-vals org-authz #(set (map keyword %))))
+
+(defn with-org-auth [user]
+  (if (coll? (get-in user [:orgAuthz]))
+    (update user :orgAuthz coerce-org-authz)
+    user))
+
+(defprotocol MongoAdapter
+  "MongoDB operations adapter"
+  (-get-session [this id fields]
+    "Return a single document map matching the given `id`, projecting `fields`. Returns
+    nil if no document is found. Implementations must dissoc `:_id` from  the MongoDB
+    document so that the return value matches the `SessionResult` schema.")
+  (-update-session! [this id session]
+    "Execute a MongoDB update with `query` and $set the `session` to the document.
+     Does NOT insert if document does not already exist.")
+  (-insert-session! [this id session]
+    "Execute a MongoDB insert with `id` as the document :_id and `session` as the other
+    document data")
+  (-remove-session! [this id]
+    "Remove the document with the given `id`."))
+
+(sc/defschema Session
+  "Data $set on every session write."
+  {:data                         sc/Any
+   :user-id                      (sc/maybe sc/Str)
+   :updated-at                   Date
+   (sc/optional-key :created-at) Date})
+
+(sc/defschema SessionResult
+  "Schema for a session document read from the database."
+  (st/optional-keys Session))
+
+(sc/defn ^:private get-session :- (sc/maybe SessionResult)
+  [adapter :- (sc/protocol MongoAdapter)
+   id :- sc/Str
+   fields :- [sc/Keyword]]
+  (-get-session adapter id fields))
+
+(sc/defn ^:private update-session!
+  [adapter :- (sc/protocol MongoAdapter)
+   id :- sc/Str
+   session :- Session]
+  (-update-session! adapter id session))
+
+(sc/defn ^:private insert-session!
+  [adapter :- (sc/protocol MongoAdapter)
+   id :- sc/Str
+   session :- Session]
+  (-insert-session! adapter id session))
+
+(sc/defn ^:private remove-session!
+  [adapter :- (sc/protocol MongoAdapter)
+   id :- sc/Str]
+  (-remove-session! adapter id))
+
+(defrecord MongoSessionStore [adapter read-only?] store/SessionStore
+  (read-session [_ key]
+    (when key
+      (some-> (get-session adapter (session-id->db-id key) [:data])
+              :data
+              (update :user with-org-auth))))
+
+  (write-session [_ key data]
+    (if read-only?
+      key
+      (let [now     (now-date)
+            new-key (or key (new-session-key))]
+        (if (nil? key)
+          (insert-session! adapter
+                           (session-id->db-id new-key)
+                           {:data       data
+                            :user-id    (get-in data [:user :id])
+                            :updated-at now
+                            :created-at now})
+          (update-session! adapter
+                           (session-id->db-id new-key)
+                           {:data       data
+                            :user-id    (get-in data [:user :id])
+                            :updated-at now}))
+        new-key)))
+
+  (delete-session [_ key]
+    (when (and (not read-only?) key)
+      (remove-session! adapter (session-id->db-id key)))
+    nil))
+
+(defn make-store
+  "Create Ring SessionStore backed by MongoDB.
+  `adapter`    – an implementation of MongoAdapter.
+  `read-only?` – when true, write-session and delete-session are no-ops. Defaults to false"
+  ([adapter & {:keys [read-only?]}]
+   (->MongoSessionStore adapter (boolean read-only?))))

--- a/test/lupapiste_commons/ring/mongo_session_test.clj
+++ b/test/lupapiste_commons/ring/mongo_session_test.clj
@@ -1,0 +1,147 @@
+(ns lupapiste-commons.ring.mongo-session-test
+  (:require [clojure.test :refer :all]
+            [ring.middleware.session.store :as store]
+            [schema.core :as sc]
+            [lupapiste-commons.ring.mongo-session :as mongo-session])
+  (:import [java.util Date]))
+
+(use-fixtures :once (fn [tests] (sc/with-fn-validation (tests))))
+
+(defn- track-calls
+  "Returns an atom and a function. The function records each call's args into the atom
+  and returns `return-val`."
+  [return-val]
+  (let [calls (atom [])]
+    [calls (fn [& args] (swap! calls conj (vec args)) return-val)]))
+
+(defn- test-adapter
+  "Builds a MongoAdapter from individual functions."
+  [{:keys [get-session update-session! insert-session! remove-session!]
+    :or   {get-session     (constantly nil)
+           update-session! (constantly nil)
+           insert-session! (constantly nil)
+           remove-session! (constantly nil)}}]
+  (reify mongo-session/MongoAdapter
+    (-get-session [_ id fields] (get-session id fields))
+    (-update-session! [_ id session] (update-session! id {"$set" session}))
+    (-insert-session! [_ id session] (insert-session! id session))
+    (-remove-session! [_ id] (remove-session! id))))
+
+(deftest coerce-org-authz-test
+  (testing "converts string values to keyword sets"
+    (is (= {:org-1 #{:authority :reader}
+            :org-2 #{:admin}}
+           (mongo-session/coerce-org-authz {:org-1 ["authority" "reader"]
+                                            :org-2 ["admin"]}))))
+  (testing "handles empty map"
+    (is (= {} (mongo-session/coerce-org-authz {}))))
+  (testing "handles already-keyword values"
+    (is (= {:org-1 #{:authority}}
+           (mongo-session/coerce-org-authz {:org-1 [:authority]})))))
+
+(deftest with-org-auth-test
+  (testing "coerces orgAuthz when it is a collection"
+    (is (= {:name "u" :orgAuthz {:org-1 #{:authority}}}
+           (mongo-session/with-org-auth {:name "u" :orgAuthz {:org-1 ["authority"]}}))))
+  (testing "returns user unchanged when orgAuthz is nil"
+    (is (= {:name "u"} (mongo-session/with-org-auth {:name "u"}))))
+  (testing "returns user unchanged when orgAuthz is not a collection"
+    (is (= {:name "u" :orgAuthz nil}
+           (mongo-session/with-org-auth {:name "u" :orgAuthz nil}))))
+  (testing "returns nil when user is nil"
+    (is (= nil
+           (mongo-session/with-org-auth nil)))))
+
+(deftest read-session-test
+  (testing "returns nil when key is nil"
+    (let [session-store (mongo-session/make-store (test-adapter {}))]
+      (is (nil? (store/read-session session-store nil)))))
+
+  (testing "returns nil when session not found"
+    (let [session-store (mongo-session/make-store (test-adapter {:get-session (constantly nil)}))]
+      (is (nil? (store/read-session session-store "some-key")))))
+
+  (testing "returns data with orgAuthz coerced when found"
+    (let [stored-data   {:data {:user {:name     "Test User"
+                                       :orgAuthz {:org-1 ["authority" "reader"]}}
+                                :foo  "bar"}}
+          [get-calls mock-get] (track-calls stored-data)
+          session-store (mongo-session/make-store (test-adapter {:get-session mock-get}))]
+      (is (= {:user {:name     "Test User"
+                     :orgAuthz {:org-1 #{:authority :reader}}}
+              :foo  "bar"}
+             (store/read-session session-store "some-key")))
+      (is (= [[(mongo-session/session-id->db-id "some-key") [:data]]]
+             @get-calls))))
+
+  (testing "returns data when user has no orgAuthz"
+    (let [stored-data   {:data {:user {:name "Test User"} :foo "bar"}}
+          session-store (mongo-session/make-store (test-adapter {:get-session (constantly stored-data)}))]
+      (is (= {:user {:name "Test User"} :foo "bar"}
+             (store/read-session session-store "some-key"))))))
+
+(deftest write-session-test
+  (testing "creates new session (nil key) — inserts"
+    (let [[insert-calls mock-insert] (track-calls nil)
+          session-store (mongo-session/make-store (test-adapter {:insert-session! mock-insert}))]
+      (let [new-key (store/write-session session-store nil {:user {:id "user-1"}})]
+        (is (string? new-key))
+        (is (= 43 (count new-key)))
+        (is (re-matches #"^[A-Za-z0-9_-]{43}$" new-key))
+        (is (= 1 (count @insert-calls)))
+        (let [[id update-doc] (first @insert-calls)]
+          (is (= (mongo-session/session-id->db-id new-key) id))
+          (is (= {:user {:id "user-1"}} (get update-doc :data)))
+          (is (= "user-1" (get update-doc :user-id)))
+          (is (instance? Date (get update-doc :updated-at)))
+          (is (instance? Date (get update-doc :created-at)))))))
+
+  (testing "updates existing session (non-nil key, no rotation) — plain update, returns same key"
+    (let [[update-calls mock-update] (track-calls nil)
+          [insert-calls mock-insert] (track-calls nil)
+          session-store (mongo-session/make-store (test-adapter {:update-session! mock-update
+                                                                 :insert-session! mock-insert}))]
+      (let [returned-key (store/write-session session-store "existing-key" {:user {:id "user-1"}})]
+        (is (= "existing-key" returned-key))
+        (is (= 0 (count @insert-calls)) "should NOT insert for existing key")
+        (is (= 1 (count @update-calls)))
+        (let [[id update-doc] (first @update-calls)]
+          (is (= (mongo-session/session-id->db-id "existing-key") id))
+          (is (= {:user {:id "user-1"}} (get-in update-doc ["$set" :data])))
+          (is (= "user-1" (get-in update-doc ["$set" :user-id])))
+          (is (instance? Date (get-in update-doc ["$set" :updated-at])))
+          (is (nil? (get update-doc "$setOnInsert")) "no $setOnInsert on plain update")))))
+
+  (testing "read-only mode returns key unchanged, no DB calls"
+    (let [[insert-calls mock-insert] (track-calls nil)
+          [update-calls mock-update] (track-calls nil)
+          session-store (mongo-session/make-store (test-adapter {:insert-session! mock-insert
+                                                                 :update-session! mock-update})
+                                                  {:read-only? true})]
+      (is (= "my-key" (store/write-session session-store "my-key" {:user {:id "u"}})))
+      (is (= 0 (count @insert-calls)))
+      (is (= 0 (count @update-calls)))))
+
+  (testing "read-only mode with nil key returns nil"
+    (let [session-store (mongo-session/make-store (test-adapter {}) {:read-only? true})]
+      (is (nil? (store/write-session session-store nil {:user {:id "u"}}))))))
+
+(deftest delete-session-test
+  (testing "removes session from database"
+    (let [[remove-calls mock-remove] (track-calls nil)
+          session-store (mongo-session/make-store (test-adapter {:remove-session! mock-remove}))]
+      (is (nil? (store/delete-session session-store "some-key")))
+      (is (= 1 (count @remove-calls)))
+      (is (= [(mongo-session/session-id->db-id "some-key")] (first @remove-calls)))))
+
+  (testing "does nothing when key is nil"
+    (let [[remove-calls mock-remove] (track-calls nil)
+          session-store (mongo-session/make-store (test-adapter {:remove-session! mock-remove}))]
+      (is (nil? (store/delete-session session-store nil)))
+      (is (= 0 (count @remove-calls)))))
+
+  (testing "does nothing when read-only"
+    (let [[remove-calls mock-remove] (track-calls nil)
+          session-store (mongo-session/make-store (test-adapter {:remove-session! mock-remove}) {:read-only? true})]
+      (is (nil? (store/delete-session session-store "some-key")))
+      (is (= 0 (count @remove-calls))))))


### PR DESCRIPTION
## Ring SessionStore Mongoon (PR 1/5)

Käytetään korvaamaan Ringin oletus-SessionStore, jotta sessiot tallennetaan ja luetaan kannasta.

Sessioavain on 32 tavun pituinen satunnaismerkkijono ja se tallennetaan kantaan SHA-256 hashina, jotta edes teoriassa kannasta ei voi varastaa avaimia.

Vertasin toteutusta vastaavaan SQL-toteutukseen ([jdbc-ring-session](https://github.com/luminus-framework/jdbc-ring-session/blob/master/src/jdbc_ring_session/core.clj)), ja siellä avaimena käytetään vain `randomUUID`:tä sellaisenaan. Intuitio sano, että se on liian heikko joten tein vähän sitkeemmän, mutta mene ja tiedä 🤷‍♂️ 

Tälle tarvii antaa parametrina funktiot mongon kutsumiseen, jotka käärii kantayhteyden sisäänsä eli kutsuminen sovelluksen puolelta tapahtuu esimerkiksi. 

```
(mongo-session/make-store 
  (partial mc/find-one-as-map db)
  (partial mc/update db)
  (partial mc/remove db)
  true)
```

`read-only?`-parametri tarkoittaa sitä ettei koskaan yritetäkään kirjoittaa sessiokantaan mitään. Sen avulla tätä voi käyttää pelkillä kannan lukuoikeuksilla. Miinuksena siinä toki on se, että pelkillä lukuoikeuksilla ei session kestoa jatketa.
